### PR TITLE
Add void recordSeasonTicketExit(String ticketId)

### DIFF
--- a/A3 source files/src/src/bcccp/tickets/season/SeasonTicketDAO.java
+++ b/A3 source files/src/src/bcccp/tickets/season/SeasonTicketDAO.java
@@ -108,6 +108,15 @@ public class SeasonTicketDAO implements ISeasonTicketDAO {
 		IUsageRecord usage = factory.make(ticketId, datetime);
 		ticket.recordUsage(usage);		
 	}
+	
+	public void recordSeasonTicketExit(String ticketId) {
+		ISeasonTicket ticket = findTicketById(ticketId);
+		if (ticket == null) throw new RuntimeException("finaliseTicketUsage : no such ticket: " + ticketId);
+		if (ticket.inUse()) throw new RuntimeException("finaliseTicketUsage : ticket " + ticketId + " is in use");
+		
+		long dateTime = System.currentTimeMillis();
+		ticket.endUsage(dateTime);
+	}
 }
 
 


### PR DESCRIPTION
Author: Anh T Nguyen
public void recordSeasonTicketExit(String ticketId)
Causes the current usage record of the season ticket associated with ticketID to be finalized.
Throws a RuntimeException if the season ticket associated with ticketId does not exist, or is currently in use.